### PR TITLE
fix: compiling issue while build in Android

### DIFF
--- a/android/src/main/java/com/appiconchanger/AppIconChangerModule.kt
+++ b/android/src/main/java/com/appiconchanger/AppIconChangerModule.kt
@@ -52,7 +52,7 @@ class AppIconChangerModule(
 
     @ReactMethod
     fun getActiveIcon(promise: Promise) {
-        val activity: Activity? = currentActivity
+        val activity: Activity? = reactApplicationContext.currentActivity
         if (activity == null) {
             promise.reject("ACTIVITY_NOT_FOUND", "Activity was not found")
             return
@@ -127,7 +127,7 @@ class AppIconChangerModule(
         isChangingIcon = true
         
         try {
-            val activity = currentActivity
+            val activity = reactApplicationContext.currentActivity
             if (activity == null) {
                 Log.w(TAG, "Activity is null, cannot complete icon change")
                 return
@@ -177,7 +177,7 @@ class AppIconChangerModule(
     @ReactMethod
     @Synchronized
     fun setIcon(iconName: String?, promise: Promise) {
-        val activity = currentActivity
+        val activity = reactApplicationContext.currentActivity
         if (activity == null) {
             promise.reject("ACTIVITY_NOT_FOUND", "The activity is null. Check if the app is running properly.")
             return


### PR DESCRIPTION
**Root Cause:**
Recent React Native versions have changed how native modules access the current Activity.
Direct usage of currentActivity inside Kotlin modules is no longer valid in this context. Instead, access must go through reactApplicationContext.

**Fix**:
Replaced all usages of : currentActivity with **reactApplicationContext.currentActivity**

This aligns with the updated React Native Native Module API and restores compatibility.